### PR TITLE
Generalise Problem Construction for BCs

### DIFF
--- a/prototype_code/ProblemAssemblyPrototype.py
+++ b/prototype_code/ProblemAssemblyPrototype.py
@@ -1,0 +1,103 @@
+import numpy as np
+
+def problem_assembly_prototype(E, A, u0, f, t, h):
+    """
+    Python equivalent of the MATLAB ProblemAssemblyPrototype function.
+
+    Assembles the global stiffness matrix K and force vector F for a 1D finite element problem.
+
+    Parameters:
+    -----------
+    E : float
+        Young's modulus (elasticity)
+    A : float
+        Cross-sectional area
+    u0 : float
+        Dirichlet boundary condition value at left boundary
+    f : float
+        Distributed force per unit volume
+    t : float
+        Neumann boundary condition value at right boundary (traction)
+    h : array-like
+        Element sizes (lengths)
+
+    Returns:
+    --------
+    K : numpy.ndarray
+        Global stiffness matrix (n_el x n_el)
+    F : numpy.ndarray
+        Global force vector (n_el x 1)
+    """
+    n_el = len(h)
+    K = np.zeros((n_el, n_el))
+    F = np.zeros((n_el, 1))
+
+    # Shape function integrals and derivatives
+    iN1 = 1.0  # Integral of N1 over the xi range [-1, 1]
+    iN2 = 1.0  # Integral of N2 over the xi range [-1, 1]
+    dN1 = -0.5  # Derivative of N1 with respect to xi
+    dN2 = 0.5   # Derivative of N2 with respect to xi
+
+    # Loop through elements for assembly
+    for i in range(n_el - 1):
+        # Local stiffness matrix
+        K_local = 4 * E * A / h[i] * np.array([
+            [dN1 * dN1, dN1 * dN2],
+            [dN2 * dN1, dN2 * dN2]
+        ])
+
+        # Local force vector
+        F_local = f * A * h[i] * np.array([[iN1], [iN2]])
+
+        # Assembly into global matrices
+        K[i:i+2, i:i+2] += K_local
+        F[i:i+2] += F_local
+
+    # Apply Dirichlet boundary condition at left boundary
+    K[0, 0] += 4 * E * A / h[0] * dN2 * dN2
+    F[0] += h[0] - 4 * E * A / h[0] * dN1 * dN2 * u0
+
+    # Apply Neumann boundary condition at right boundary
+    F[-1] += t * A
+
+    return K, F
+
+
+def main():
+    """
+    Example usage and test of the problem_assembly_prototype function.
+    """
+    # Example parameters
+    E = 1.0      # Young's modulus
+    A = 1.0      # Cross-sectional area
+    u0 = 273.15  # Dirichlet BC (temperature at left boundary)
+    f = 1.0      # Distributed force
+    t = 100.0    # Neumann BC (heat flux at right boundary)
+    h = [1.0, 1.0, 1.0, 1.0, 1.0]  # Element sizes (5 elements of size 1)
+
+    # Assemble matrices
+    K, F = problem_assembly_prototype(E, A, u0, f, t, h)
+
+    print("Global Stiffness Matrix K:")
+    print(K)
+    print("\nGlobal Force Vector F:")
+    print(F)
+
+    # Verify the expected structure for this example
+    print("\nExpected K matrix structure (for verification):")
+    expected_K = np.array([
+        [2.0, -1.0, 0.0, 0.0, 0.0],
+        [-1.0, 2.0, -1.0, 0.0, 0.0],
+        [0.0, -1.0, 2.0, -1.0, 0.0],
+        [0.0, 0.0, -1.0, 2.0, -1.0],
+        [0.0, 0.0, 0.0, -1.0, 1.0]
+    ])
+    print(expected_K)
+
+    print("\nExpected F vector structure (for verification):")
+    expected_F = np.array([[273.15 + 2.0], [2.0], [2.0], [2.0], [1.0 + 100.0]])
+    print(expected_F)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lin_alg.rs
+++ b/src/lin_alg.rs
@@ -85,6 +85,19 @@ fn qr_decomposition(A: &mat::Matrix<f64>) -> (mat::Matrix<f64>, mat::Matrix<f64>
 mod tests {
     use super::*;
 
+    // Helper function to check if all elements of a matrix are below a tolerance
+    fn matrix_elements_below_tolerance(matrix: &mat::Matrix<f64>, tolerance: f64) -> bool {
+        let (rows, cols) = matrix.get_dim();
+        for r in 0..rows {
+            for c in 0..cols {
+                if matrix.get(r, c) >= tolerance {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
     #[test]
     fn test_qr_decomposition() {
         let mut a = mat::Matrix::new((3, 3));
@@ -124,13 +137,20 @@ mod tests {
         r_expected.set(2, 1, 0.000000000000000);
         r_expected.set(2, 2, -2.373464415855720);
 
-        for i in 0..3 {
-            for j in 0..3 {
-                assert!((a.get(i, j) - a_reconstructed.get(i, j)).abs() < 1e-10);
-                assert!((q.get(i, j) - q_expected.get(i, j)).abs() < 1e-10);
-                assert!((r.get(i, j) - r_expected.get(i, j)).abs() < 1e-10);
-            }
-        }
+        // Check that Q*R reconstructs the original matrix A
+        // For floating point results, we need tolerance-based comparison
+        let reconstruction_error = (&a - &a_reconstructed).abs();
+        assert!(matrix_elements_below_tolerance(
+            &reconstruction_error,
+            1e-10
+        ));
+
+        // Note: Due to floating point precision, we can't use exact equality for Q and R
+        // so we use matrix operations with tolerance checking
+        let q_error = (&q - &q_expected).abs();
+        let r_error = (&r - &r_expected).abs();
+        assert!(matrix_elements_below_tolerance(&q_error, 1e-10));
+        assert!(matrix_elements_below_tolerance(&r_error, 1e-10));
     }
 
     #[test]
@@ -158,8 +178,9 @@ mod tests {
         x_expected.set(1, 0, 1.307692307692307);
         x_expected.set(2, 0, 0.230769230769231);
 
-        for i in 0..3 {
-            assert!((x.get(i, 0) - x_expected.get(i, 0)).abs() < 1e-10);
-        }
+        // Note: Due to floating point precision, we can't use exact equality
+        // so we use matrix operations with tolerance checking
+        let solution_error = (&x - &x_expected).abs();
+        assert!(matrix_elements_below_tolerance(&solution_error, 1e-10));
     }
 }

--- a/src/lin_alg/mat.rs
+++ b/src/lin_alg/mat.rs
@@ -2,6 +2,7 @@
 Implements a basic 2D matrix struct and some fundamental operations.
 */
 
+#[derive(Debug)]
 pub struct Matrix<T> {
     data: Vec<T>,
     dim: (usize, usize),
@@ -64,6 +65,18 @@ impl Matrix<f64> {
 
     pub fn norm(&self) -> f64 {
         return self.dot_product(self).sqrt();
+    }
+
+    pub fn abs(&self) -> Matrix<f64> {
+        let mut result: Matrix<f64> = Matrix::<f64>::new(self.dim);
+
+        for r in 0..self.dim.0 {
+            for c in 0..self.dim.1 {
+                result.set(r, c, self.get(r, c).abs())
+            }
+        }
+
+        return result;
     }
 }
 
@@ -226,6 +239,23 @@ impl std::ops::Mul<f64> for &Matrix<f64> {
     }
 }
 
+// Reference == Reference
+impl PartialEq for Matrix<f64> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.dim != other.dim {
+            return false;
+        }
+        for r in 0..self.dim.0 {
+            for c in 0..self.dim.1 {
+                if self.get(r, c) != other.get(r, c) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}
+
 // Reference / Scalar
 impl std::ops::Div<f64> for &Matrix<f64> {
     type Output = Matrix<f64>;
@@ -349,6 +379,23 @@ mod tests {
     }
 
     #[test]
+    fn test_matrix_abs() {
+        let mut m: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        m.set(0, 0, 0.0);
+        m.set(0, 1, 1.0);
+        m.set(1, 0, -2.0);
+        m.set(1, 1, 3.0);
+
+        let mut m_expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        m_expected.set(0, 0, 0.0);
+        m_expected.set(0, 1, 1.0);
+        m_expected.set(1, 0, 2.0);
+        m_expected.set(1, 1, 3.0);
+
+        assert_eq!(m.abs(), m_expected);
+    }
+
+    #[test]
     fn test_matrix_add() {
         let mut m1: Matrix<f64> = Matrix::<f64>::new((2, 2));
         m1.set(0, 0, 1.0);
@@ -362,11 +409,14 @@ mod tests {
         m2.set(1, 0, 7.0);
         m2.set(1, 1, 8.0);
 
-        let m3: Matrix<f64> = m1 + m2;
-        assert_eq!(m3.get(0, 0), 6.0);
-        assert_eq!(m3.get(0, 1), 8.0);
-        assert_eq!(m3.get(1, 0), 10.0);
-        assert_eq!(m3.get(1, 1), 12.0);
+        let mut expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected.set(0, 0, 6.0);
+        expected.set(0, 1, 8.0);
+        expected.set(1, 0, 10.0);
+        expected.set(1, 1, 12.0);
+
+        let result: Matrix<f64> = m1 + m2;
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -377,17 +427,17 @@ mod tests {
         m1.set(1, 0, 3.0);
         m1.set(1, 1, 4.0);
 
-        let m2: Matrix<f64> = &m1 + 10.0;
-        assert_eq!(m2.get(0, 0), 11.0);
-        assert_eq!(m2.get(0, 1), 12.0);
-        assert_eq!(m2.get(1, 0), 13.0);
-        assert_eq!(m2.get(1, 1), 14.0);
+        let mut expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected.set(0, 0, 11.0);
+        expected.set(0, 1, 12.0);
+        expected.set(1, 0, 13.0);
+        expected.set(1, 1, 14.0);
 
-        let m3: Matrix<f64> = 10.0 + &m1;
-        assert_eq!(m3.get(0, 0), 11.0);
-        assert_eq!(m3.get(0, 1), 12.0);
-        assert_eq!(m3.get(1, 0), 13.0);
-        assert_eq!(m3.get(1, 1), 14.0);
+        let result1: Matrix<f64> = &m1 + 10.0;
+        assert_eq!(result1, expected);
+
+        let result2: Matrix<f64> = 10.0 + &m1;
+        assert_eq!(result2, expected);
     }
 
     #[test]
@@ -404,11 +454,14 @@ mod tests {
         m2.set(1, 0, 3.0);
         m2.set(1, 1, 4.0);
 
-        let m3: Matrix<f64> = m1 - m2;
-        assert_eq!(m3.get(0, 0), 4.0);
-        assert_eq!(m3.get(0, 1), 4.0);
-        assert_eq!(m3.get(1, 0), 4.0);
-        assert_eq!(m3.get(1, 1), 4.0);
+        let mut expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected.set(0, 0, 4.0);
+        expected.set(0, 1, 4.0);
+        expected.set(1, 0, 4.0);
+        expected.set(1, 1, 4.0);
+
+        let result: Matrix<f64> = m1 - m2;
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -419,17 +472,23 @@ mod tests {
         m1.set(1, 0, 3.0);
         m1.set(1, 1, 4.0);
 
-        let m2: Matrix<f64> = &m1 - 10.0;
-        assert_eq!(m2.get(0, 0), -9.0);
-        assert_eq!(m2.get(0, 1), -8.0);
-        assert_eq!(m2.get(1, 0), -7.0);
-        assert_eq!(m2.get(1, 1), -6.0);
+        let mut expected1: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected1.set(0, 0, -9.0);
+        expected1.set(0, 1, -8.0);
+        expected1.set(1, 0, -7.0);
+        expected1.set(1, 1, -6.0);
 
-        let m3: Matrix<f64> = 10.0 - &m1;
-        assert_eq!(m3.get(0, 0), 9.0);
-        assert_eq!(m3.get(0, 1), 8.0);
-        assert_eq!(m3.get(1, 0), 7.0);
-        assert_eq!(m3.get(1, 1), 6.0);
+        let mut expected2: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected2.set(0, 0, 9.0);
+        expected2.set(0, 1, 8.0);
+        expected2.set(1, 0, 7.0);
+        expected2.set(1, 1, 6.0);
+
+        let result1: Matrix<f64> = &m1 - 10.0;
+        assert_eq!(result1, expected1);
+
+        let result2: Matrix<f64> = 10.0 - &m1;
+        assert_eq!(result2, expected2);
     }
 
     #[test]
@@ -446,11 +505,14 @@ mod tests {
         m2.set(1, 0, 7.0);
         m2.set(1, 1, 8.0);
 
-        let m3: Matrix<f64> = m1 * m2;
-        assert_eq!(m3.get(0, 0), 19.0);
-        assert_eq!(m3.get(0, 1), 22.0);
-        assert_eq!(m3.get(1, 0), 43.0);
-        assert_eq!(m3.get(1, 1), 50.0);
+        let mut expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected.set(0, 0, 19.0);
+        expected.set(0, 1, 22.0);
+        expected.set(1, 0, 43.0);
+        expected.set(1, 1, 50.0);
+
+        let result: Matrix<f64> = m1 * m2;
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -471,11 +533,14 @@ mod tests {
         m2.set(2, 0, 11.0);
         m2.set(2, 1, 12.0);
 
-        let m3: Matrix<f64> = m1 * m2;
-        assert_eq!(m3.get(0, 0), 58.0);
-        assert_eq!(m3.get(0, 1), 64.0);
-        assert_eq!(m3.get(1, 0), 139.0);
-        assert_eq!(m3.get(1, 1), 154.0);
+        let mut expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected.set(0, 0, 58.0);
+        expected.set(0, 1, 64.0);
+        expected.set(1, 0, 139.0);
+        expected.set(1, 1, 154.0);
+
+        let result: Matrix<f64> = m1 * m2;
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -486,17 +551,17 @@ mod tests {
         m1.set(1, 0, 3.0);
         m1.set(1, 1, 4.0);
 
-        let m2: Matrix<f64> = &m1 * 10.0;
-        assert_eq!(m2.get(0, 0), 10.0);
-        assert_eq!(m2.get(0, 1), 20.0);
-        assert_eq!(m2.get(1, 0), 30.0);
-        assert_eq!(m2.get(1, 1), 40.0);
+        let mut expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected.set(0, 0, 10.0);
+        expected.set(0, 1, 20.0);
+        expected.set(1, 0, 30.0);
+        expected.set(1, 1, 40.0);
 
-        let m3: Matrix<f64> = 10.0 * &m1;
-        assert_eq!(m3.get(0, 0), 10.0);
-        assert_eq!(m3.get(0, 1), 20.0);
-        assert_eq!(m3.get(1, 0), 30.0);
-        assert_eq!(m3.get(1, 1), 40.0);
+        let result1: Matrix<f64> = &m1 * 10.0;
+        assert_eq!(result1, expected);
+
+        let result2: Matrix<f64> = 10.0 * &m1;
+        assert_eq!(result2, expected);
     }
 
     #[test]
@@ -507,11 +572,14 @@ mod tests {
         m1.set(1, 0, 30.0);
         m1.set(1, 1, 40.0);
 
-        let m2: Matrix<f64> = &m1 / 10.0;
-        assert_eq!(m2.get(0, 0), 1.0);
-        assert_eq!(m2.get(0, 1), 2.0);
-        assert_eq!(m2.get(1, 0), 3.0);
-        assert_eq!(m2.get(1, 1), 4.0);
+        let mut expected: Matrix<f64> = Matrix::<f64>::new((2, 2));
+        expected.set(0, 0, 1.0);
+        expected.set(0, 1, 2.0);
+        expected.set(1, 0, 3.0);
+        expected.set(1, 1, 4.0);
+
+        let result: Matrix<f64> = &m1 / 10.0;
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -524,10 +592,7 @@ mod tests {
 
         let m2: Matrix<f64> = m1.clone();
         assert_eq!(m2.get_dim(), (2, 2));
-        assert_eq!(m2.get(0, 0), 1.0);
-        assert_eq!(m2.get(0, 1), 2.0);
-        assert_eq!(m2.get(1, 0), 3.0);
-        assert_eq!(m2.get(1, 1), 4.0);
+        assert_eq!(m1, m2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ fn main() {
     let n_elements: usize = 100;
     let thermal_conductivity: f64 = 45.0; // W/m.K for steel
     let area = 0.01; // m^2
-    let dirichlet_bc: f64 = 373.15; // Temperature at left end in K
-    let neumann_bc: f64 = -1000.0; // Heat flux at right end in W/m^2
+    let left_bc: problem::BoundaryCondition = problem::BoundaryCondition::Dirichlet(373.15); // Temperature at left end in K
+    let right_bc: problem::BoundaryCondition = problem::BoundaryCondition::Dirichlet(-1000.0); // Heat flux at right end in W/m^2
 
     println!("Simulating heat conduction in a {length} m rod with {n_elements} elements...");
 
@@ -24,7 +24,7 @@ fn main() {
     mesh.area = area;
     mesh.internal_force = -25.0; // W/m^3, volumetric heat generation/loss
 
-    let mut problem: problem::Problem1D = problem::Problem1D::new(mesh, dirichlet_bc, neumann_bc);
+    let mut problem: problem::Problem1D = problem::Problem1D::new(mesh, left_bc, right_bc);
     problem.solve();
 
     println!("Nodal temperatures (°C):");

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -166,24 +166,7 @@ mod test {
         f_expected.set(4, 0, 1.0 + 100.0);
 
         let (k, f) = problem.construct_matrices();
-        for i in 0..5 {
-            for j in 0..5 {
-                assert!(
-                    (k.get(i, j) - k_expected.get(i, j)).abs() < 1e-10,
-                    "K[i: {}, j: {}] = {}, expected {}",
-                    i,
-                    j,
-                    k.get(i, j),
-                    k_expected.get(i, j)
-                );
-            }
-            assert!(
-                (f.get(i, 0) - f_expected.get(i, 0)).abs() < 1e-10,
-                "F[i: {}] = {}, expected {}",
-                i,
-                f.get(i, 0),
-                f_expected.get(i, 0)
-            );
-        }
+        assert_eq!(k, k_expected);
+        assert_eq!(f, f_expected);
     }
 }

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -39,8 +39,8 @@ impl Problem1D {
     }
 
     fn construct_matrices(&self) -> (mat::Matrix<f64>, mat::Matrix<f64>) {
-        let int_N1: f64 = 1.0;
-        let int_N2: f64 = 1.0;
+        let int_n1: f64 = 1.0;
+        let int_n2: f64 = 1.0;
         let int_dn1: f64 = -0.5;
         let int_dn2: f64 = 0.5;
 
@@ -72,8 +72,8 @@ impl Problem1D {
             k_local.set(1, 0, k_fac_element * int_dn2 * int_dn1);
             k_local.set(1, 1, k_fac_element * int_dn2 * int_dn2);
 
-            f_local.set(0, 0, f_fac_element * int_N1);
-            f_local.set(1, 0, f_fac_element * int_N2);
+            f_local.set(0, 0, f_fac_element * int_n1);
+            f_local.set(1, 0, f_fac_element * int_n2);
 
             // Assemble into global matrices
             k.set(i - 1, i - 1, k.get(i - 1, i - 1) + k_local.get(0, 0));

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -7,6 +7,11 @@ use crate::lin_alg;
 use crate::lin_alg::mat;
 use crate::meshing::Mesh1D;
 
+pub enum BoundaryCondition {
+    Dirichlet(f64),
+    Neumann(f64),
+}
+
 pub struct Problem1D {
     pub mesh: Mesh1D,
     dirichlet_condition: f64,
@@ -107,6 +112,22 @@ impl Problem1D {
 mod test {
     use super::*;
     use crate::meshing;
+
+    #[test]
+    fn test_bc_enum() {
+        let dirichlet = BoundaryCondition::Dirichlet(100.0);
+        let neumann = BoundaryCondition::Neumann(50.0);
+
+        match dirichlet {
+            BoundaryCondition::Dirichlet(val) => assert_eq!(val, 100.0),
+            _ => panic!("Expected Dirichlet condition"),
+        }
+
+        match neumann {
+            BoundaryCondition::Neumann(val) => assert_eq!(val, 50.0),
+            _ => panic!("Expected Neumann condition"),
+        }
+    }
 
     #[test]
     fn test_problem_construction() {

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -14,16 +14,16 @@ pub enum BoundaryCondition {
 
 pub struct Problem1D {
     pub mesh: Mesh1D,
-    dirichlet_condition: f64,
-    neumann_condition: f64,
+    pub left_bc: BoundaryCondition,
+    pub right_bc: BoundaryCondition,
 }
 
 impl Problem1D {
-    pub fn new(mesh: Mesh1D, dirichlet_condition: f64, neumann_condition: f64) -> Self {
+    pub fn new(mesh: Mesh1D, left_bc: BoundaryCondition, right_bc: BoundaryCondition) -> Self {
         return Self {
             mesh,
-            dirichlet_condition,
-            neumann_condition,
+            left_bc,
+            right_bc,
         };
     }
 
@@ -32,9 +32,27 @@ impl Problem1D {
         let d: mat::Matrix<f64> = lin_alg::lin_solve(&k, &f);
 
         // Apply nodal values to mesh
-        self.mesh.node_values[0] = self.dirichlet_condition;
-        for i in 1..self.mesh.get_n_elements() + 1 {
-            self.mesh.node_values[i] = d.get(i - 1, 0);
+        // Length of d depends on the boundary conditions
+        let n_el = self.mesh.get_n_elements();
+        let mut node_idx: usize = 0;
+
+        match self.left_bc {
+            BoundaryCondition::Dirichlet(val) => {
+                self.mesh.node_values[0] = val;
+                node_idx += 1;
+            }
+            BoundaryCondition::Neumann(_) => {}
+        }
+
+        for i in 0..d.get_dim().0 {
+            self.mesh.node_values[i + node_idx] = d.get(i, 0);
+        }
+
+        match self.right_bc {
+            BoundaryCondition::Dirichlet(val) => {
+                self.mesh.node_values[n_el] = val;
+            }
+            BoundaryCondition::Neumann(_) => {}
         }
     }
 
@@ -45,15 +63,49 @@ impl Problem1D {
         let int_dn2: f64 = 0.5;
 
         let n_el: usize = self.mesh.get_n_elements();
-        // Stiffness matrix (discounting first node due to Dirichlet BC)
-        let mut k: mat::Matrix<f64> = mat::Matrix::new((n_el, n_el));
-        // Force matrix (discounting first node due to Dirichlet BC)
-        let mut f: mat::Matrix<f64> = mat::Matrix::new((n_el, 1));
+        // Matrix sizes depend on the degrees of freedom, where Dirichlet BC reduces by 1
+        let mut n_dof: usize = n_el + 1;
+        match self.left_bc {
+            BoundaryCondition::Dirichlet(_) => n_dof -= 1,
+            _ => {}
+        }
+        match self.right_bc {
+            BoundaryCondition::Dirichlet(_) => n_dof -= 1,
+            _ => {}
+        }
+
+        let mut k: mat::Matrix<f64> = mat::Matrix::new((n_dof, n_dof));
+        let mut f: mat::Matrix<f64> = mat::Matrix::new((n_dof, 1));
 
         let k_fac: f64 = 4.0 * self.mesh.elasticity * self.mesh.area;
         let f_fac: f64 = self.mesh.internal_force * self.mesh.area;
 
-        for i in 1..n_el {
+        // Apply left boundary condition
+        let k_fac_local: f64 = match self.mesh.get_element_size(0) {
+            Some(size) => k_fac / size,
+            None => panic!("Element size not found"),
+        };
+
+        let f_fac_local: f64 = match self.mesh.get_element_size(0) {
+            Some(size) => f_fac * size,
+            None => panic!("Element size not found"),
+        };
+
+        match self.left_bc {
+            BoundaryCondition::Dirichlet(val) => {
+                k.set(0, 0, k.get(0, 0) + k_fac_local * int_dn2 * int_dn2);
+                f.set(
+                    0,
+                    0,
+                    f.get(0, 0) + f_fac_local * int_n2 - k_fac_local * int_dn1 * int_dn2 * val,
+                );
+            }
+            BoundaryCondition::Neumann(val) => {
+                f.set(0, 0, f.get(0, 0) + val * self.mesh.area);
+            }
+        }
+
+        for i in 0..(n_dof - 1) {
             let mut k_local: mat::Matrix<f64> = mat::Matrix::new((2, 2));
             let mut f_local: mat::Matrix<f64> = mat::Matrix::new((2, 1));
 
@@ -76,33 +128,44 @@ impl Problem1D {
             f_local.set(1, 0, f_fac_element * int_n2);
 
             // Assemble into global matrices
-            k.set(i - 1, i - 1, k.get(i - 1, i - 1) + k_local.get(0, 0));
-            k.set(i - 1, i, k.get(i - 1, i) + k_local.get(0, 1));
-            k.set(i, i - 1, k.get(i, i - 1) + k_local.get(1, 0));
-            k.set(i, i, k.get(i, i) + k_local.get(1, 1));
+            k.set(i, i, k.get(i, i) + k_local.get(0, 0));
+            k.set(i, i + 1, k.get(i, i + 1) + k_local.get(0, 1));
+            k.set(i + 1, i, k.get(i + 1, i) + k_local.get(1, 0));
+            k.set(i + 1, i + 1, k.get(i + 1, i + 1) + k_local.get(1, 1));
 
-            f.set(i - 1, 0, f.get(i - 1, 0) + f_local.get(0, 0));
-            f.set(i, 0, f.get(i, 0) + f_local.get(1, 0));
+            f.set(i, 0, f.get(i, 0) + f_local.get(0, 0));
+            f.set(i + 1, 0, f.get(i + 1, 0) + f_local.get(1, 0));
         }
 
-        // Adjust for Dirichlet boundary condition
-        let k_fac_local = match self.mesh.get_element_size(0) {
+        // Adjust for right boundary condition
+        let k_fac_local: f64 = match self.mesh.get_element_size(n_el - 1) {
             Some(size) => k_fac / size,
             None => panic!("Element size not found"),
         };
 
-        k.set(0, 0, k.get(0, 0) + k_fac_local * int_dn2 * int_dn2);
-        f.set(
-            0,
-            0,
-            f.get(0, 0) - k_fac_local * int_dn1 * int_dn2 * self.dirichlet_condition,
-        );
-        // Adjust for Neumann boundary condition
-        f.set(
-            n_el - 1,
-            0,
-            f.get(n_el - 1, 0) + self.neumann_condition * self.mesh.area,
-        );
+        let f_fac_local: f64 = match self.mesh.get_element_size(n_el - 1) {
+            Some(size) => f_fac * size,
+            None => panic!("Element size not found"),
+        };
+
+        match self.right_bc {
+            BoundaryCondition::Dirichlet(val) => {
+                k.set(
+                    n_dof - 1,
+                    n_dof - 1,
+                    k.get(n_dof - 1, n_dof - 1) + k_fac_local * int_dn1 * int_dn1,
+                );
+                f.set(
+                    n_dof - 1,
+                    0,
+                    f.get(n_dof - 1, 0) + f_fac_local * int_n1
+                        - k_fac_local * int_dn1 * int_dn2 * val,
+                );
+            }
+            BoundaryCondition::Neumann(val) => {
+                f.set(n_dof - 1, 0, f.get(n_dof - 1, 0) + val * self.mesh.area);
+            }
+        }
 
         return (k, f);
     }
@@ -130,7 +193,7 @@ mod test {
     }
 
     #[test]
-    fn test_problem_construction() {
+    fn test_problem_construction_dirichlet_neumann() {
         let mut mesh: meshing::Mesh1D = meshing::Mesh1D::uniform_mesh(5.0, 5); // To ensure elements are of size 1
 
         // Set all material properties to 1 for simplicity
@@ -138,9 +201,12 @@ mod test {
         mesh.area = 1.0;
         mesh.internal_force = 1.0;
 
-        let problem: Problem1D = Problem1D::new(mesh, 273.15, 100.0);
-        assert_eq!(problem.dirichlet_condition, 273.15);
-        assert_eq!(problem.neumann_condition, 100.0);
+        let left_bc = BoundaryCondition::Dirichlet(273.15);
+        let right_bc = BoundaryCondition::Neumann(100.0);
+
+        let problem: Problem1D = Problem1D::new(mesh, left_bc, right_bc);
+        // assert_eq!(problem.dirichlet_condition, 273.15);
+        // assert_eq!(problem.neumann_condition, 100.0);
         assert_eq!(problem.mesh.get_n_elements(), 5);
 
         let mut k_expected: mat::Matrix<f64> = mat::Matrix::new((5, 5));
@@ -159,11 +225,143 @@ mod test {
         k_expected.set(4, 4, 1.0);
 
         let mut f_expected: mat::Matrix<f64> = mat::Matrix::new((5, 1));
-        f_expected.set(0, 0, 273.15 + 1.0);
+        f_expected.set(0, 0, 273.15 + 2.0);
         f_expected.set(1, 0, 2.0);
         f_expected.set(2, 0, 2.0);
         f_expected.set(3, 0, 2.0);
         f_expected.set(4, 0, 1.0 + 100.0);
+
+        let (k, f) = problem.construct_matrices();
+        assert_eq!(k, k_expected);
+        assert_eq!(f, f_expected);
+    }
+
+    #[test]
+    fn test_problem_construction_neumann_dirichlet() {
+        let mut mesh: meshing::Mesh1D = meshing::Mesh1D::uniform_mesh(5.0, 5); // To ensure elements are of size 1
+
+        // Set all material properties to 1 for simplicity
+        mesh.elasticity = 1.0;
+        mesh.area = 1.0;
+        mesh.internal_force = 1.0;
+
+        let left_bc = BoundaryCondition::Neumann(50.0);
+        let right_bc = BoundaryCondition::Dirichlet(373.15);
+
+        let problem: Problem1D = Problem1D::new(mesh, left_bc, right_bc);
+        // assert_eq!(problem.dirichlet_condition, 273.15);
+        // assert_eq!(problem.neumann_condition, 100.0);
+        assert_eq!(problem.mesh.get_n_elements(), 5);
+
+        let mut k_expected: mat::Matrix<f64> = mat::Matrix::new((5, 5));
+        k_expected.set(0, 0, 1.0);
+        k_expected.set(0, 1, -1.0);
+        k_expected.set(1, 0, -1.0);
+        k_expected.set(1, 1, 2.0);
+        k_expected.set(1, 2, -1.0);
+        k_expected.set(2, 1, -1.0);
+        k_expected.set(2, 2, 2.0);
+        k_expected.set(2, 3, -1.0);
+        k_expected.set(3, 2, -1.0);
+        k_expected.set(3, 3, 2.0);
+        k_expected.set(3, 4, -1.0);
+        k_expected.set(4, 3, -1.0);
+        k_expected.set(4, 4, 2.0);
+
+        let mut f_expected: mat::Matrix<f64> = mat::Matrix::new((5, 1));
+        f_expected.set(0, 0, 50.0 + 1.0);
+        f_expected.set(1, 0, 2.0);
+        f_expected.set(2, 0, 2.0);
+        f_expected.set(3, 0, 2.0);
+        f_expected.set(4, 0, 2.0 + 373.15);
+
+        let (k, f) = problem.construct_matrices();
+        assert_eq!(k, k_expected);
+        assert_eq!(f, f_expected);
+    }
+
+    #[test]
+    fn test_problem_construction_pure_dirichlet() {
+        let mut mesh: meshing::Mesh1D = meshing::Mesh1D::uniform_mesh(5.0, 5); // To ensure elements are of size 1
+
+        // Set all material properties to 1 for simplicity
+        mesh.elasticity = 1.0;
+        mesh.area = 1.0;
+        mesh.internal_force = 1.0;
+
+        let left_bc = BoundaryCondition::Dirichlet(273.15);
+        let right_bc = BoundaryCondition::Dirichlet(373.15);
+
+        let problem: Problem1D = Problem1D::new(mesh, left_bc, right_bc);
+        // assert_eq!(problem.dirichlet_condition, 273.15);
+        // assert_eq!(problem.neumann_condition, 100.0);
+        assert_eq!(problem.mesh.get_n_elements(), 5);
+
+        let mut k_expected: mat::Matrix<f64> = mat::Matrix::new((4, 4));
+        k_expected.set(0, 0, 2.0);
+        k_expected.set(0, 1, -1.0);
+        k_expected.set(1, 0, -1.0);
+        k_expected.set(1, 1, 2.0);
+        k_expected.set(1, 2, -1.0);
+        k_expected.set(2, 1, -1.0);
+        k_expected.set(2, 2, 2.0);
+        k_expected.set(2, 3, -1.0);
+        k_expected.set(3, 2, -1.0);
+        k_expected.set(3, 3, 2.0);
+
+        let mut f_expected: mat::Matrix<f64> = mat::Matrix::new((4, 1));
+        f_expected.set(0, 0, 273.15 + 2.0);
+        f_expected.set(1, 0, 2.0);
+        f_expected.set(2, 0, 2.0);
+        f_expected.set(3, 0, 373.15 + 2.0);
+
+        let (k, f) = problem.construct_matrices();
+        assert_eq!(k, k_expected);
+        assert_eq!(f, f_expected);
+    }
+
+    #[test]
+    fn test_problem_construction_pure_neumann() {
+        let mut mesh: meshing::Mesh1D = meshing::Mesh1D::uniform_mesh(5.0, 5); // To ensure elements are of size 1
+
+        // Set all material properties to 1 for simplicity
+        mesh.elasticity = 1.0;
+        mesh.area = 1.0;
+        mesh.internal_force = 1.0;
+
+        let left_bc = BoundaryCondition::Neumann(50.0);
+        let right_bc = BoundaryCondition::Neumann(100.0);
+
+        let problem: Problem1D = Problem1D::new(mesh, left_bc, right_bc);
+        // assert_eq!(problem.dirichlet_condition, 273.15);
+        // assert_eq!(problem.neumann_condition, 100.0);
+        assert_eq!(problem.mesh.get_n_elements(), 5);
+
+        let mut k_expected: mat::Matrix<f64> = mat::Matrix::new((6, 6));
+        k_expected.set(0, 0, 1.0);
+        k_expected.set(0, 1, -1.0);
+        k_expected.set(1, 0, -1.0);
+        k_expected.set(1, 1, 2.0);
+        k_expected.set(1, 2, -1.0);
+        k_expected.set(2, 1, -1.0);
+        k_expected.set(2, 2, 2.0);
+        k_expected.set(2, 3, -1.0);
+        k_expected.set(3, 2, -1.0);
+        k_expected.set(3, 3, 2.0);
+        k_expected.set(3, 4, -1.0);
+        k_expected.set(4, 3, -1.0);
+        k_expected.set(4, 4, 2.0);
+        k_expected.set(4, 5, -1.0);
+        k_expected.set(5, 4, -1.0);
+        k_expected.set(5, 5, 1.0);
+
+        let mut f_expected: mat::Matrix<f64> = mat::Matrix::new((6, 1));
+        f_expected.set(0, 0, 50.0 + 1.0);
+        f_expected.set(1, 0, 2.0);
+        f_expected.set(2, 0, 2.0);
+        f_expected.set(3, 0, 2.0);
+        f_expected.set(4, 0, 2.0);
+        f_expected.set(5, 0, 1.0 + 100.0);
 
         let (k, f) = problem.construct_matrices();
         assert_eq!(k, k_expected);


### PR DESCRIPTION
Generalising the problem construction to allow different kinds of boundary conditions at the left and right nodes.